### PR TITLE
Add reaction role module

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -29,6 +29,7 @@ import { checkForAccessByRoles } from "./src/helper/roleAuth";
 import { incomingMessageSchema } from "./src/models/incomingMessage";
 import { Delete } from "./src/models/customTypes";
 import { guildJoin } from "./src/controllers/sendMessageHandler";
+import { addReaction, removeReaction } from "./src/helper/reactionRole";
 /******************************************
           Initialize Server
 *******************************************/
@@ -87,7 +88,7 @@ async function createServer() {
             );
           }
         }
-        message.react(process.env.CUSTOM_EMOJI_ID!).catch((err) => {
+        message.react("🤡").catch((err) => {
           serverLogger("non-fatal-error", "Could not find custom emoji", err);
         });
       }
@@ -156,6 +157,14 @@ async function createServer() {
 
   client!.on("voiceStateUpdate", (oldState, newState) => {
     handleVoiceStatus(oldState, newState);
+  });
+
+  client!.on("messageReactionAdd", (reaction, user) => {
+    addReaction(reaction, user);
+  });
+
+  client!.on("messageReactionRemove", (reaction, user) => {
+    removeReaction(reaction, user);
   });
 }
 

--- a/index.ts
+++ b/index.ts
@@ -88,7 +88,7 @@ async function createServer() {
             );
           }
         }
-        message.react("🤡").catch((err) => {
+        message.react(process.env.CUSTOM_EMOJI_ID!).catch((err) => {
           serverLogger("non-fatal-error", "Could not find custom emoji", err);
         });
       }

--- a/index.ts
+++ b/index.ts
@@ -9,6 +9,7 @@ import { COMMANDS } from "./src/utils/constants";
 import { initDbClient, initEventDbClient } from "./src/utils/database";
 import { initCache, refreshKeys } from "./src/utils/nodecache";
 import {
+  handleAvatarUpdate,
   handleChannelCreate,
   handleChannelDelete,
   handleChannelUpdate,
@@ -165,6 +166,10 @@ async function createServer() {
 
   client!.on("messageReactionRemove", (reaction, user) => {
     removeReaction(reaction, user);
+  });
+
+  client!.on("userUpdate", (oldUser, newUser) => {
+    handleAvatarUpdate(oldUser, newUser, client!);
   });
 }
 

--- a/src/controllers/incomingMessageHandler.ts
+++ b/src/controllers/incomingMessageHandler.ts
@@ -13,6 +13,7 @@ import { startCheckIn } from "../helper/checkIn";
 import { createBasicEmbed, getHelpMessage } from "../utils/messages";
 import { sendDirectMessageToUser } from "./sendMessageHandler";
 import { incomingMessageSchema } from "../models/incomingMessage";
+import { handleReactionRoles } from "../helper/reactionRole";
 /**
  * Handles all incoming commands in a text channel
  *
@@ -73,6 +74,10 @@ export async function handleIncomingChannelCommand(
       case COMMANDS.help: {
         incomingMessage.channel.send(getHelpMessage(messageType));
         serverLogger("success", incomingMessage.content, "Help Message");
+        break;
+      }
+      case COMMANDS.reactionRole: {
+        handleReactionRoles(incomingMessage, messageType);
         break;
       }
       default:

--- a/src/controllers/incomingMessageHandler.ts
+++ b/src/controllers/incomingMessageHandler.ts
@@ -42,11 +42,6 @@ export async function handleIncomingChannelCommand(
       }
       case COMMANDS.announce: {
         handleAnnouncements(incomingMessage, messageType);
-        serverLogger(
-          "success",
-          incomingMessage.content.split(" ").splice(0, 5),
-          "Announcements"
-        );
         break;
       }
       case COMMANDS.joke: {

--- a/src/helper/announcement.ts
+++ b/src/helper/announcement.ts
@@ -15,86 +15,86 @@ export async function handleAnnouncements(
   incomingMessage: Message,
   messageType: incomingMessageSchema
 ) {
+  if (!messageType.incomingUser.isMod) {
+    serverLogger("user-error", incomingMessage.content, "Unauthorized User");
+    return incomingMessage.channel.send(
+      `<@${messageType.incomingUser.id}>`,
+      createBasicEmbed(ERRORS.UNAUTHORIZED_USER, "ERROR")
+    );
+  }
   try {
-    if (messageType.incomingUser.isMod) {
-      const regex = new RegExp(
-        `^${COMMANDS.prefix} ${COMMANDS.announce}( here | everyone | | <@&.+> )<#.+> \{.*\} (.|\n)+$`,
-        "g"
+    const regex = new RegExp(
+      `^${COMMANDS.prefix} ${COMMANDS.announce}( here | everyone | | <@&.+> )<#.+> \{.*\} (.|\n)+$`,
+      "g"
+    );
+    if (regex.test(incomingMessage.content)) {
+      let channelId = incomingMessage.content.match(/<#.+?>/)![0];
+      channelId = channelId.substring(2, channelId.length - 1);
+      let title = incomingMessage.content.match(/\{.*?\}/)![0];
+      title = title.substring(1, title.length - 1);
+      const announcement = incomingMessage.content.substring(
+        incomingMessage.content.indexOf("} ") + 2
       );
-      if (regex.test(incomingMessage.content)) {
-        let channelId = incomingMessage.content.match(/<#.+?>/)![0];
-        channelId = channelId.substring(2, channelId.length - 1);
-        let title = incomingMessage.content.match(/\{.*?\}/)![0];
-        title = title.substring(1, title.length - 1);
-        const announcement = incomingMessage.content.substring(
-          incomingMessage.content.indexOf("} ") + 2
+      const channel = incomingMessage.guild?.channels.cache.find(
+        (ch) => ch.id == channelId
+      );
+      if (channel && (channel?.type === "text" || channel?.type === "news")) {
+        const everyoneRegex = new RegExp(
+          `^${COMMANDS.prefix} ${COMMANDS.announce} everyone`
         );
-        const channel = incomingMessage.guild?.channels.cache.find(
-          (ch) => ch.id == channelId
+        const hereRegex = new RegExp(
+          `^${COMMANDS.prefix} ${COMMANDS.announce} here`
         );
-        if (channel && (channel?.type === "text" || channel?.type === "news")) {
-          const everyoneRegex = new RegExp(
-            `^${COMMANDS.prefix} ${COMMANDS.announce} everyone`
-          );
-          const hereRegex = new RegExp(
-            `^${COMMANDS.prefix} ${COMMANDS.announce} here`
-          );
-          const roleMentionRegex = new RegExp(
-            `^${COMMANDS.prefix} ${COMMANDS.announce} <@&.+>`
-          );
-          if (everyoneRegex.test(incomingMessage.content)) {
-            (channel as TextChannel | NewsChannel).send(
-              "**📢 Announcement @everyone!**",
-              {
-                embed: announcementMessage(title, announcement),
-              }
-            );
-          } else if (hereRegex.test(incomingMessage.content)) {
-            (channel as TextChannel | NewsChannel).send(
-              "**📢 Announcement @here!**",
-              {
-                embed: announcementMessage(title, announcement),
-              }
-            );
-          } else if (roleMentionRegex.test(incomingMessage.content)) {
-            let roleId = incomingMessage.content.split(" ")[2];
-            roleId = roleId.substring(3, roleId.length - 1);
-            console.log(roleId);
-            (channel as TextChannel | NewsChannel).send(
-              `**📢 Announcement <@&${roleId}>!**`,
-              {
-                embed: announcementMessage(title, announcement),
-              }
-            );
-          } else {
-            (channel as TextChannel | NewsChannel).send({
+        const roleMentionRegex = new RegExp(
+          `^${COMMANDS.prefix} ${COMMANDS.announce} <@&.+>`
+        );
+        if (everyoneRegex.test(incomingMessage.content)) {
+          (channel as TextChannel | NewsChannel).send(
+            "**📢 Announcement @everyone!**",
+            {
               embed: announcementMessage(title, announcement),
-            });
-          }
-          incomingMessage.channel.send("Sent! :white_check_mark: ");
+            }
+          );
+        } else if (hereRegex.test(incomingMessage.content)) {
+          (channel as TextChannel | NewsChannel).send(
+            "**📢 Announcement @here!**",
+            {
+              embed: announcementMessage(title, announcement),
+            }
+          );
+        } else if (roleMentionRegex.test(incomingMessage.content)) {
+          let roleId = incomingMessage.content.split(" ")[2];
+          roleId = roleId.substring(3, roleId.length - 1);
+          console.log(roleId);
+          (channel as TextChannel | NewsChannel).send(
+            `**📢 Announcement <@&${roleId}>!**`,
+            {
+              embed: announcementMessage(title, announcement),
+            }
+          );
         } else {
-          throw Error;
+          (channel as TextChannel | NewsChannel).send({
+            embed: announcementMessage(title, announcement),
+          });
         }
-      } else {
+        incomingMessage.channel.send("Sent! :white_check_mark: ");
         serverLogger(
-          "user-error",
+          "success",
           incomingMessage.content.split(" ").splice(0, 5),
-          "Invalid command"
+          "Announcements"
         );
-        incomingMessage.channel.send(
-          `<@${messageType.incomingUser.id}>`,
-          createBasicEmbed(ERRORS.INVALID_COMMAND, "ERROR")
-        );
+      } else {
+        throw Error;
       }
     } else {
       serverLogger(
         "user-error",
         incomingMessage.content.split(" ").splice(0, 5),
-        "Unauthorized User"
+        "Invalid command"
       );
       incomingMessage.channel.send(
         `<@${messageType.incomingUser.id}>`,
-        createBasicEmbed(ERRORS.UNAUTHORIZED_USER, "ERROR")
+        createBasicEmbed(ERRORS.INVALID_COMMAND, "ERROR")
       );
     }
   } catch (err) {

--- a/src/helper/memberLogs.ts
+++ b/src/helper/memberLogs.ts
@@ -5,6 +5,7 @@ import {
   Guild,
   GuildMember,
   PartialGuildMember,
+  PartialUser,
   Role,
   TextChannel,
   User,
@@ -261,6 +262,28 @@ export function handleVoiceStatus(
     else if (oldStatus.channel?.id) embed.setColor(COLORS.LEAVE_VOICE);
     else if (newStatus.channel?.id) embed.setColor(COLORS.JOIN_VOICE);
     channel.send(embed);
+  } catch (err) {
+    serverLogger("error", "InternalError", err);
+  }
+}
+
+export function handleAvatarUpdate(
+  oldUser: User | PartialUser,
+  newUser: User,
+  client: Client
+) {
+  try {
+    const channel = client?.channels.cache.find(
+      (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
+    ) as TextChannel;
+    if (!channel) return;
+    if (oldUser.avatar !== newUser.avatar)
+      channel.send(
+        createBasicEmbed(
+          INFO.AVATAR_UPDATED(oldUser, newUser),
+          "LOG_2"
+        ).setThumbnail(newUser.displayAvatarURL()!)
+      );
   } catch (err) {
     serverLogger("error", "InternalError", err);
   }

--- a/src/helper/memberLogs.ts
+++ b/src/helper/memberLogs.ts
@@ -61,14 +61,18 @@ export function handleChannelCreate(
   newChannel: Channel,
   client: Client | undefined
 ) {
-  try {
-    const channel = client?.channels.cache.find(
-      (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
-    ) as TextChannel;
-    if (!channel) return;
-    channel.send(createBasicEmbed(INFO.CHANNEL_CREATED(newChannel), "SUCCESS"));
-  } catch (err) {
-    serverLogger("error", "InternalError", err);
+  if (newChannel.type === "text" || newChannel.type === "voice") {
+    try {
+      const channel = client?.channels.cache.find(
+        (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
+      ) as TextChannel;
+      if (!channel) return;
+      channel.send(
+        createBasicEmbed(INFO.CHANNEL_CREATED(newChannel), "SUCCESS")
+      );
+    } catch (err) {
+      serverLogger("error", "InternalError", err);
+    }
   }
 }
 
@@ -88,14 +92,18 @@ export function handleChannelDelete(
   deleteChannel: Delete,
   client: Client | undefined
 ) {
-  try {
-    const channel = client?.channels.cache.find(
-      (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
-    ) as TextChannel;
-    if (!channel) return;
-    channel.send(createBasicEmbed(INFO.CHANNEL_DELETE(deleteChannel), "INFO"));
-  } catch (err) {
-    serverLogger("error", "InternalError", err);
+  if (deleteChannel.type === "text" || deleteChannel.type === "voice") {
+    try {
+      const channel = client?.channels.cache.find(
+        (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
+      ) as TextChannel;
+      if (!channel) return;
+      channel.send(
+        createBasicEmbed(INFO.CHANNEL_DELETE(deleteChannel), "INFO")
+      );
+    } catch (err) {
+      serverLogger("error", "InternalError", err);
+    }
   }
 }
 export function handleMemberUnban(guild: Guild, user: User) {
@@ -114,16 +122,18 @@ export function handleChannelUpdate(
   updateChannel: Channel,
   client: Client | undefined
 ) {
-  try {
-    const channel = client?.channels.cache.find(
-      (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
-    ) as TextChannel;
-    if (!channel) return;
-    channel.send(
-      createBasicEmbed(INFO.CHANNEL_UPDATE(updateChannel), "SUCCESS")
-    );
-  } catch (err) {
-    serverLogger("error", "InternalError", err);
+  if (updateChannel.type === "text" || updateChannel.type === "voice") {
+    try {
+      const channel = client?.channels.cache.find(
+        (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
+      ) as TextChannel;
+      if (!channel) return;
+      channel.send(
+        createBasicEmbed(INFO.CHANNEL_UPDATE(updateChannel), "SUCCESS")
+      );
+    } catch (err) {
+      serverLogger("error", "InternalError", err);
+    }
   }
 }
 export function handleMemberUpdate(

--- a/src/helper/memberLogs.ts
+++ b/src/helper/memberLogs.ts
@@ -152,6 +152,30 @@ export function handleMemberUpdate(
           "LOG_2"
         ).setThumbnail(CONSTANTS.AVATAR_URL(newUser.voice))
       );
+    if (oldUser.roles.cache.size > newUser.roles.cache.size) {
+      oldUser.roles.cache.forEach((role) => {
+        if (!newUser.roles.cache.has(role.id)) {
+          channel.send(
+            createBasicEmbed(
+              INFO.MEMBED_ROLE_REMOVE(oldUser, role),
+              "LOG_1"
+            ).setThumbnail(CONSTANTS.AVATAR_URL(newUser.voice))
+          );
+        }
+      });
+    }
+    if (oldUser.roles.cache.size < newUser.roles.cache.size) {
+      newUser.roles.cache.forEach((role) => {
+        if (!oldUser.roles.cache.has(role.id)) {
+          channel.send(
+            createBasicEmbed(
+              INFO.MEMBED_ROLE_ADD(newUser, role),
+              "LOG_2"
+            ).setThumbnail(CONSTANTS.AVATAR_URL(newUser.voice))
+          );
+        }
+      });
+    }
   } catch (err) {
     serverLogger("error", "InternalError", err);
   }

--- a/src/helper/reactionRole.ts
+++ b/src/helper/reactionRole.ts
@@ -144,7 +144,7 @@ const createReactionRoleMessage = async (
 
 const addRoleData = async (roleData: roleSchema) => {
   try {
-    const db = await (await getDbClient()).db().collection("roles");
+    const db = await (await getDbClient()).db().collection("reaction-roles");
     const { insertedCount } = await db.insertOne(roleData);
     if (insertedCount <= 0) throw { message: "MongoDB Poll Insert Error" };
     const result = await setRole(roleData);
@@ -160,7 +160,7 @@ const addRoleData = async (roleData: roleSchema) => {
 
 const refreshRoleData = async (roleData: roleSchema) => {
   try {
-    const db = await (await getDbClient()).db().collection("roles");
+    const db = await (await getDbClient()).db().collection("reaction-roles");
     await db.updateOne(
       { messageID: roleData.messageID },
       { $set: { reactions: roleData.reactions } }

--- a/src/helper/reactionRole.ts
+++ b/src/helper/reactionRole.ts
@@ -207,13 +207,6 @@ export const addReaction = async (
           });
           await refreshRoleData(roleData);
           serverLogger("success", "role added", ``);
-          const channel = reaction.message.guild?.channels.cache.find(
-            (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
-          ) as TextChannel;
-          if (channel)
-            channel.send(
-              createBasicEmbed(INFO.REACTION_ROLE_ADD(role, userAdd), "LOG_2")
-            );
         }
       }
     });
@@ -258,16 +251,6 @@ export const removeReaction = async (
                 )
               );
             await refreshRoleData(roleData);
-            const channel = reaction.message.guild?.channels.cache.find(
-              (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
-            ) as TextChannel;
-            if (channel)
-              channel.send(
-                createBasicEmbed(
-                  INFO.REACTION_ROLE_REMOVE(role, userAdd),
-                  "LOG_1"
-                )
-              );
           }
         }
       }

--- a/src/helper/reactionRole.ts
+++ b/src/helper/reactionRole.ts
@@ -1,0 +1,327 @@
+import {
+  Message,
+  TextChannel,
+  PartialUser,
+  MessageReaction,
+  User,
+} from "discord.js";
+import { serverLogger } from "../utils/logger";
+import { createBasicEmbed } from "../utils/messages";
+import { COMMANDS, ERRORS, INFO } from "../utils/constants";
+import { incomingMessageSchema } from "../models/incomingMessage";
+import { roleSchema } from "../models/reactionRole";
+import { getDbClient } from "../utils/database";
+import { getRole, setRole } from "../utils/nodecache";
+
+/**
+ * Handles role assignment
+ *
+ * @param {Message} incomingMessage
+ * @param {incomingMessageSchema} messageType
+ */
+
+export async function handleReactionRoles(
+  incomingMessage: Message,
+  messageType: incomingMessageSchema
+) {
+  const reactionRoleRegex = new RegExp(
+    `^${COMMANDS.prefix} ${COMMANDS.reactionRole} (<#.+?>) (\{(?:.|\n)*\}) (\\[.*\\])$`
+  );
+  if (messageType.incomingUser.isMod) {
+    try {
+      if (reactionRoleRegex.test(incomingMessage.content.trim())) {
+        const tokens = incomingMessage.content.match(
+          reactionRoleRegex
+        ) as Array<string>;
+        const channelID = tokens[1].substring(2, tokens[1].length - 1);
+        const description = tokens[2].substring(1, tokens[2].length - 1);
+        let rolesArray = tokens[3]
+          .substring(2, tokens[3].length - 2)
+          .split("],[")
+          .map((str) => str.trim());
+        if (rolesArray.length < 2)
+          return incomingMessage.channel.send(
+            createBasicEmbed(ERRORS.ROLE_MISSING, "ERROR")
+          );
+        const roleRegex = new RegExp(`<@&.+>`);
+        for (let i = 0; i < rolesArray.length; i += 2) {
+          if (!roleRegex.test(rolesArray[i]))
+            return incomingMessage.channel.send(
+              createBasicEmbed(ERRORS.INVALID_ROLE, "ERROR")
+            );
+        }
+        let optionsArray: Array<{
+          roleID: string;
+          emoji: string;
+        }> = [];
+        for (let i = 0; i < rolesArray.length; i += 2) {
+          optionsArray.push({
+            roleID: rolesArray[i].substring(3, rolesArray[i].length - 1),
+            emoji: rolesArray[i + 1],
+          });
+        }
+        createReactionRoleMessage(
+          {
+            description: description.trim(),
+            guildName: incomingMessage.guild?.name!,
+            channelID: channelID,
+            messageID: "",
+            options: optionsArray,
+            reactions: [],
+            guildID: incomingMessage.guild?.id!,
+            timestamp: "",
+          },
+          incomingMessage,
+          messageType
+        );
+      } else {
+        serverLogger(
+          "user-error",
+          incomingMessage.content.trim(),
+          "Syntax error"
+        );
+        incomingMessage.channel.send(
+          `<@${messageType.incomingUser.id}>`,
+          createBasicEmbed(ERRORS.ROLE_SYNTAX_ERROR, "ERROR")
+        );
+      }
+    } catch (err) {
+      incomingMessage.channel.send(
+        `<@${messageType.incomingUser.id}>`,
+        createBasicEmbed(ERRORS.ROLE_ERROR, "ERROR")
+      );
+      serverLogger(
+        "user-error",
+        err.message,
+        "Announcement to invalid channel"
+      );
+    }
+  } else {
+    serverLogger("user-error", incomingMessage.content, "Unauthorized User");
+    incomingMessage.channel.send(
+      `<@${messageType.incomingUser.id}>`,
+      createBasicEmbed(ERRORS.UNAUTHORIZED_USER, "ERROR")
+    );
+  }
+}
+
+const createReactionRoleMessage = async (
+  roleData: roleSchema,
+  incomingMessage: Message,
+  messageType: incomingMessageSchema
+) => {
+  try {
+    const channel = incomingMessage.guild?.channels.cache.find(
+      (ch: any) => ch.id === roleData.channelID
+    ) as TextChannel;
+    if (!channel)
+      return incomingMessage.channel.send("The channel does not exist");
+    let message = await channel.send(
+      createBasicEmbed(
+        { title: "React to get your Roles!🎉", message: roleData.description },
+        "REACTION_ROLE"
+      )
+    );
+    roleData.messageID = message.id;
+    roleData.timestamp = new Date();
+    await addRoleData(roleData);
+    for (let i = 0; i < roleData.options.length; i++) {
+      message.react(roleData.options[i].emoji).catch((err) => {
+        throw { message: err.message };
+      });
+    }
+    incomingMessage.channel.send("Reaction role message Sent ✅");
+  } catch (error) {
+    serverLogger(
+      "internal-error",
+      "reaction role message error",
+      error.message
+    );
+    incomingMessage.channel.send(
+      `<@${messageType.incomingUser.id}>`,
+      createBasicEmbed(ERRORS.ROLE_ERROR, "ERROR")
+    );
+  }
+};
+
+const addRoleData = async (roleData: roleSchema) => {
+  try {
+    const db = await (await getDbClient()).db().collection("roles");
+    const { insertedCount } = await db.insertOne(roleData);
+    if (insertedCount <= 0) throw { message: "MongoDB Poll Insert Error" };
+    const result = await setRole(roleData);
+    if (!result) throw { message: "nodecache error" };
+  } catch (error) {
+    serverLogger(
+      "internal-error",
+      "Unable to add Data to database and/or cache",
+      error.message
+    );
+  }
+};
+
+const refreshRoleData = async (roleData: roleSchema) => {
+  try {
+    const db = await (await getDbClient()).db().collection("roles");
+    await db.updateOne(
+      { messageID: roleData.messageID },
+      { $set: { reactions: roleData.reactions } }
+    );
+    const resultNodeCache = await setRole(roleData);
+    if (!resultNodeCache) throw { message: "nodecache error" };
+  } catch (error) {
+    serverLogger(
+      "internal-error",
+      "Unable to update data on database and/or cache",
+      error.message
+    );
+  }
+};
+
+export const addReaction = async (
+  reaction: MessageReaction,
+  user: User | PartialUser
+) => {
+  try {
+    if (!user.bot) {
+      const roleData = await getRole(reaction.message.id);
+      if (roleData) {
+        let userTag = roleData.reactions.find(
+          (userData) => userData.id === user.id
+        );
+        if (userTag) {
+          return reaction.users.remove(user.id);
+        }
+        let roles = roleData.options;
+        roles.forEach((data) => {
+          let emoji;
+          const emojiRegex = new RegExp(`(\:.*\:)`);
+          if (emojiRegex.test(data.emoji)) {
+            emoji = (data.emoji.match(emojiRegex) as Array<string>)[0];
+            emoji = emoji?.substring(1, emoji.length - 1);
+          } else emoji = data.emoji;
+          if (emoji === reaction.emoji.name) {
+            let role = reaction.message.guild?.roles.cache.find(
+              (role) => role.id === data.roleID
+            );
+            let userAdd = reaction.message.guild?.members.cache.get(user.id);
+            if (role && userAdd) {
+              if (userAdd.roles.cache.find((r) => r === role)) return;
+              userAdd.roles
+                .add(role)
+                .catch((error) => {
+                  throw { message: error.message };
+                })
+                .then(() => {
+                  roleData.reactions.push({
+                    id: user.id,
+                    tag: user.tag!,
+                    roleID: data.roleID,
+                  });
+                  refreshRoleData(roleData);
+                  serverLogger("success", "role added", ``);
+                  const channel = reaction.message.guild?.channels.cache.find(
+                    (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
+                  ) as TextChannel;
+                  if (channel)
+                    channel.send(
+                      createBasicEmbed(
+                        INFO.REACTION_ROLE_ADD(role, userAdd),
+                        "LOG_2"
+                      )
+                    );
+                });
+            }
+          }
+        });
+      }
+    }
+  } catch (error) {
+    serverLogger("internal-error", "unable to assign roles", error.message);
+  }
+};
+
+export const removeReaction = async (
+  reaction: MessageReaction,
+  user: User | PartialUser
+) => {
+  try {
+    if (!user.bot) {
+      const roleData = await getRole(reaction.message.id);
+      if (!roleData) return;
+      if (roleData) {
+        let roles = roleData.options;
+        roles.forEach((data) => {
+          let emoji: string;
+          const emojiRegex = new RegExp(`(\:.*\:)`);
+          if (emojiRegex.test(data.emoji)) {
+            emoji = (data.emoji.match(emojiRegex) as Array<string>)[0];
+            emoji = emoji?.substring(1, emoji.length - 1);
+          } else emoji = data.emoji;
+          if (emoji === reaction.emoji.name) {
+            let role = reaction.message.guild?.roles.cache.find(
+              (role) => role.id === data.roleID
+            );
+            let userAdd = reaction.message.guild?.members.cache.get(user.id);
+            if (role && userAdd) {
+              if (userAdd.roles.cache.find((r) => r === role)) {
+                userAdd.roles
+                  .remove(role)
+                  .catch((error) => {
+                    throw { message: error.message };
+                  })
+                  .then(() => {
+                    serverLogger("success", "role removed", ``);
+                    roleData!.reactions = roleData!.reactions
+                      .slice(
+                        0,
+                        roleData!.reactions.findIndex((i) =>
+                          compareReactionsObject(i, user, data)
+                        )
+                      )
+                      .concat(
+                        roleData!.reactions.slice(
+                          roleData!.reactions.findIndex((i) =>
+                            compareReactionsObject(i, user, data)
+                          ) + 1
+                        )
+                      );
+                    refreshRoleData(roleData);
+                    const channel = reaction.message.guild?.channels.cache.find(
+                      (ch: any) => ch.id === process.env.LOGGER_CHANNEL_ID
+                    ) as TextChannel;
+                    if (channel)
+                      channel.send(
+                        createBasicEmbed(
+                          INFO.REACTION_ROLE_REMOVE(role, userAdd),
+                          "LOG_1"
+                        )
+                      );
+                  });
+              }
+            }
+          }
+        });
+      }
+    }
+  } catch (error) {
+    serverLogger("internal-error", "unable to remove role", error.message);
+  }
+};
+
+const compareReactionsObject = (
+  i: { id: string; tag: string; roleID: string },
+  user: User | PartialUser,
+  data: { roleID: string; emoji: string }
+) => {
+  if (
+    JSON.stringify(i) ===
+    JSON.stringify({
+      id: user.id!,
+      tag: user.tag!,
+      roleID: data.roleID,
+    })
+  )
+    return true;
+  return false;
+};

--- a/src/models/reactionRole.ts
+++ b/src/models/reactionRole.ts
@@ -1,0 +1,13 @@
+export interface roleSchema {
+  guildName: string;
+  description: string;
+  messageID: string;
+  channelID: string;
+  options: Array<{
+    roleID: string;
+    emoji: string;
+  }>;
+  reactions: Array<{ id: string; tag: string; roleID: string }>;
+  guildID: string;
+  timestamp: Date | string;
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,6 +7,7 @@ import {
   PartialGuildMember,
   Role,
   VoiceState,
+  Guild,
 } from "discord.js";
 import { config } from "dotenv";
 import { Delete } from "../models/customTypes";
@@ -98,6 +99,25 @@ export const ERRORS = {
   CHECKIN_CREATE_FAIL: {
     title: "Checkin Collector Creation Failed!",
     message: "There has been some error while creating the check-in collector!",
+  },
+  ROLE_MISSING: {
+    title: "Error!😭",
+    message:
+      "Please recheck and make sure you have entered atleast one role(@role) and a corresponding emoji. Also make sure roles and emojis are in pair.",
+  },
+  INVALID_ROLE: {
+    title: "Error!😭",
+    message:
+      "Invalid Role! please check and enter a valid role. Please tag the role(@role).",
+  },
+  ROLE_SYNTAX_ERROR: {
+    title: "Error!😭",
+    message: `Please follow the proper syntax. Use my help command to access see the proper syntax.`,
+  },
+  ROLE_ERROR: {
+    title: "error!😭",
+    message:
+      "Ooooops something went wrong! I am not quite sure what. Please check the syntax and try again. Also make sure the mentioned roles exist in the guild.",
   },
 };
 
@@ -280,6 +300,24 @@ export const INFO = {
       message: ``,
     };
   },
+  REACTION_ROLE_REMOVE: (
+    role: Role | undefined,
+    userAdd: GuildMember | undefined
+  ) => {
+    return {
+      title: "Role removed ❌",
+      message: `**${role?.name}** was removed from ${userAdd?.displayName}. \n**Tag:** ${userAdd?.user.tag}.`,
+    };
+  },
+  REACTION_ROLE_ADD: (
+    role: Role | undefined,
+    userAdd: GuildMember | undefined
+  ) => {
+    return {
+      title: "Role Alloted ✅",
+      message: `**${role?.name}** was alloted to ${userAdd?.displayName}. \n**Tag:** ${userAdd?.user.tag}`,
+    };
+  },
 };
 
 /**
@@ -297,6 +335,7 @@ export const COMMANDS = {
   cacheflush: "flush",
   createPoll: "poll",
   checkIn: "checkin",
+  reactionRole: "role",
 };
 
 /**
@@ -305,6 +344,7 @@ export const COMMANDS = {
 export const CONSTANTS = {
   thumbsUpEmoji: "👍",
   pollReactions: ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"],
+  roleReactions: ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"],
   checkinReactions: {
     accept: "✅",
     reject: "❌",
@@ -372,6 +412,7 @@ export const COLORS = {
   JOIN_VOICE: "#00ff00",
   LEAVE_VOICE: "#ff0066",
   MOVE_VOICE: "#00ccff",
+  REACTION_ROLE: "#bf00ff",
 };
 
 export const randomMemesEndpoint = () => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -7,7 +7,7 @@ import {
   PartialGuildMember,
   Role,
   VoiceState,
-  Guild,
+  PartialUser,
 } from "discord.js";
 import { config } from "dotenv";
 import { Delete } from "../models/customTypes";
@@ -248,11 +248,11 @@ export const INFO = {
   ) => {
     if (!(oldInfo.displayName === newInfo.displayName))
       return {
-        title: `${oldInfo.displayName} 's details were updated!👀`,
+        title: `${oldInfo.displayName}'s details were updated!👀`,
         message: `\n\n**Old name:** ${oldInfo.displayName}\n**new name:** ${newInfo.displayName}\n**user:** <@${oldInfo.user?.id}>\n**Tag:** ${oldInfo.user?.tag}`,
       };
     return {
-      title: `${oldInfo.displayName} 's details were updated!👀`,
+      title: `${oldInfo.displayName}'s details were updated!👀`,
       message: `\n\n**user:** <@${oldInfo.user?.id}>\n**Tag:** ${
         oldInfo.user?.tag
       }\n**Old avatar:** [**Old avatar**](${CONSTANTS.AVATAR_URL(
@@ -338,6 +338,14 @@ export const INFO = {
       message: `\n🕵️‍♂️**User name:** ${newUser.displayName}\n⚒**Role:** ${role.name}\n💻**Tag:** ${newUser.user?.tag}`,
     };
   },
+  AVATAR_UPDATED: (oldUser: User | PartialUser, newUser: User) => {
+    return {
+      title: `${oldUser.tag}'s avatar was updated 👀`,
+      message: `📸 [The old Avatar](${CONSTANTS.AVATAR_UPDATE_URL(
+        oldUser as User
+      )})\n📸 [The new Avatar](${CONSTANTS.AVATAR_UPDATE_URL(newUser)}) `,
+    };
+  },
 };
 
 /**
@@ -364,7 +372,6 @@ export const COMMANDS = {
 export const CONSTANTS = {
   thumbsUpEmoji: "👍",
   pollReactions: ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"],
-  roleReactions: ["1️⃣", "2️⃣", "3️⃣", "4️⃣", "5️⃣", "6️⃣", "7️⃣", "8️⃣", "9️⃣"],
   checkinReactions: {
     accept: "✅",
     reject: "❌",
@@ -418,6 +425,11 @@ export const CONSTANTS = {
   AVATAR_URL: (newStatus: VoiceState) => {
     if (newStatus.member?.user.avatar)
       return `https://cdn.discordapp.com/avatars/${newStatus.member?.user.id}/${newStatus.member?.user.avatar}.jpeg`;
+    return `https://cdn.discordapp.com/embed/avatars/0.png`;
+  },
+  AVATAR_UPDATE_URL: (user: User) => {
+    if (user.avatar)
+      return `https://cdn.discordapp.com/avatars/${user.id}/${user.avatar}.jpeg`;
     return `https://cdn.discordapp.com/embed/avatars/0.png`;
   },
 };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -115,9 +115,14 @@ export const ERRORS = {
     message: `Please follow the proper syntax. Use my help command to access see the proper syntax.`,
   },
   ROLE_ERROR: {
-    title: "error!😭",
+    title: "Error!😭",
     message:
-      "Ooooops something went wrong! I am not quite sure what. Please check the syntax and try again. Also make sure the mentioned roles exist in the guild.",
+      "Ooooops! something went wrong and I am not quite sure what. Please check the syntax and try again. Also, make sure the mentioned roles exist in the guild.",
+  },
+  ROLE_EMOJI_PAIR: {
+    title: "Error! 😭",
+    message:
+      "Roles and emojis must exist in pair. Please check the syntax and try and again.",
   },
 };
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -310,7 +310,7 @@ export const INFO = {
     userAdd: GuildMember | undefined
   ) => {
     return {
-      title: "Role removed ❌",
+      title: "Role removed by me❌",
       message: `**${role?.name}** was removed from ${userAdd?.displayName}. \n**Tag:** ${userAdd?.user.tag}.`,
     };
   },
@@ -319,8 +319,23 @@ export const INFO = {
     userAdd: GuildMember | undefined
   ) => {
     return {
-      title: "Role Alloted ✅",
+      title: "Role Alloted by me ✅",
       message: `**${role?.name}** was alloted to ${userAdd?.displayName}. \n**Tag:** ${userAdd?.user.tag}`,
+    };
+  },
+  MEMBED_ROLE_REMOVE: (
+    oldUser: GuildMember | PartialGuildMember,
+    role: Role
+  ) => {
+    return {
+      title: `Role removed ❌`,
+      message: `\n🕵️‍♂️**User name:** ${oldUser.displayName}\n⚒**Role:** ${role.name}\n💻**Tag:** ${oldUser.user?.tag}`,
+    };
+  },
+  MEMBED_ROLE_ADD: (newUser: GuildMember, role: Role) => {
+    return {
+      title: `Role Added ✅`,
+      message: `\n🕵️‍♂️**User name:** ${newUser.displayName}\n⚒**Role:** ${role.name}\n💻**Tag:** ${newUser.user?.tag}`,
     };
   },
 };

--- a/src/utils/discord.ts
+++ b/src/utils/discord.ts
@@ -17,7 +17,10 @@ export async function initDiscordBot() {
   try {
     let intents = new Intents(Intents.NON_PRIVILEGED);
     intents.add(["GUILD_MEMBERS", "GUILD_PRESENCES"]);
-    bot = new Discord.Client({ ws: { intents: intents } });
+    bot = new Discord.Client({
+      partials: ["MESSAGE", "CHANNEL", "REACTION"],
+      ws: { intents: intents },
+    });
     await bot.login(process.env.DISCORD_TOKEN || "");
     console.log("✔️   Discord Bot Login");
     bot.user!.setActivity("#kzjack help", {

--- a/src/utils/messages.ts
+++ b/src/utils/messages.ts
@@ -91,7 +91,12 @@ export const getHelpMessage = (messageType: incomingMessageSchema) => {
       },
       {
         name: "Start a check-in Channel [Only Mods]",
-        value: "`kzjack checkin <Event Slug>`",
+        value: "`#kzjack checkin <Event Slug>`",
+      },
+      {
+        name: "Start a Role assigner [Only Mods]",
+        value:
+          "`#kzjack role <#channel> {<description>} [[<@role1>],[<emoji to assign role1>],[<@role2>],[<emoji to assign role2>]]`",
       }
     );
   }
@@ -182,6 +187,7 @@ export const createBasicEmbed = (
     | "JOIN_VOICE"
     | "MOVE_VOICE"
     | "LEAVE_VOICE"
+    | "REACTION_ROLE"
 ) => {
   return new MessageEmbed()
     .setColor(COLORS[level])

--- a/src/utils/nodecache.ts
+++ b/src/utils/nodecache.ts
@@ -2,6 +2,7 @@ import nodeCache from "node-cache";
 import { getDbClient } from "./database";
 import { eventSchema } from "../models/event";
 import { pollSchema } from "../models/poll";
+import { roleSchema } from "../models/reactionRole";
 let cache: nodeCache;
 export const initCache = async (): Promise<nodeCache> => {
   try {
@@ -23,6 +24,10 @@ export const refreshKeys = async () => {
     const polls = await db.collection("polls").find<pollSchema>();
     await polls.forEach((poll: pollSchema) => {
       cache.set(`poll-${poll.pollID}`, JSON.stringify(poll));
+    });
+    const roles = await db.collection("roles").find<roleSchema>();
+    await roles.forEach((role: roleSchema) => {
+      cache.set(role.messageID, JSON.stringify(role));
     });
     console.log("✔️   NodeCache Keys Refreshed!");
   } catch (err) {
@@ -56,4 +61,17 @@ export const getPoll = async (id: string): Promise<pollSchema | null> => {
 export const setPoll = async (poll: pollSchema): Promise<boolean> => {
   const result = cache.set(`poll-${poll.pollID}`, JSON.stringify(poll));
   return result;
+};
+
+export const setRole = async (roleData: roleSchema): Promise<boolean> => {
+  const result = cache.set(roleData.messageID, JSON.stringify(roleData));
+  return result;
+};
+
+export const getRole = async (
+  messageID: string
+): Promise<roleSchema | null> => {
+  const roleData = cache.get(messageID) as string;
+  if (roleData) return JSON.parse(roleData);
+  return null;
 };

--- a/src/utils/nodecache.ts
+++ b/src/utils/nodecache.ts
@@ -25,7 +25,7 @@ export const refreshKeys = async () => {
     await polls.forEach((poll: pollSchema) => {
       cache.set(`poll-${poll.pollID}`, JSON.stringify(poll));
     });
-    const roles = await db.collection("roles").find<roleSchema>();
+    const roles = await db.collection("reaction-roles").find<roleSchema>();
     await roles.forEach((role: roleSchema) => {
       cache.set(role.messageID, JSON.stringify(role));
     });


### PR DESCRIPTION
Fixes #29 and #31 

# Description

1. Add a reaction role module that takes a channel, description, and an array of roles and emojis from mods and send a reactable embed to the channel. When a guild member reacts to the embed with an emoji, the corresponding role is assigned to that member. A user can only react and get one role at a time, If the member wishes to remove that role, they can do so by removing the reaction from the embed. They can then react with a different emoji and get another role. 
The roles and emojis must be given by the user in pairs. The emojis can be custom or normal, the application supports both. 

2. The application logs any channel updates(addition of a channel, deletion, and name changes) to the ledger channel. But if a user deleted jack's dm, the ledger logs that as well. This pr fixes that issue.

3. Fix issue 31 by adding event listeners for role and avatar updates and log them in the logger channel.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Tested on discord guild
