### PR TITLE
fix: collecting meme from redditAPI

### DIFF
--- a/src/helper/jokes.ts
+++ b/src/helper/jokes.ts
@@ -48,7 +48,7 @@ export async function handleJokes(
 
 async function extractMeme(url: string) {
   const { data } = await axios.get(url);
-  const children = data.data.children.filter((child: any) => child.data.url.endsWith(".jpg") || child.data.url.endsWith(".png"));
+  const children = data?.data?.children?.filter((child: any) => child.data.url.endsWith(".jpg") || child.data.url.endsWith(".png"));
   return children[Math.floor(Math.random() * children.length)].data;
 }
 

--- a/src/helper/jokes.ts
+++ b/src/helper/jokes.ts
@@ -46,6 +46,12 @@ export async function handleJokes(
   }
 }
 
+async function extractMeme(url: string) {
+  const { data } = await axios.get(url);
+  const children = data.data.children;
+  return children[Math.floor(Math.random() * children.length)].data;
+}
+
 /**
  * Handle memes commands.
  * Send some memes on the server.
@@ -57,13 +63,12 @@ export async function handleMemes(
   messageType: incomingMessageSchema
 ) {
   try {
-    const { data } = await axios.get(randomMemesEndpoint());
-    console.log(data);
+    const { title, url } = await extractMeme(randomMemesEndpoint());
     incomingMessage.channel.send(
       new MessageEmbed()
-        .setDescription(`**${data.title}**`)
+        .setDescription(`**${title}**`)
         .setColor(COLORS.INFO)
-        .setImage(data.url)
+        .setImage(url)
         .setTimestamp()
         .setFooter(CONSTANTS.FOOTER, CONSTANTS.FOOTER_LOGO_URL)
     );

--- a/src/helper/jokes.ts
+++ b/src/helper/jokes.ts
@@ -48,7 +48,7 @@ export async function handleJokes(
 
 async function extractMeme(url: string) {
   const { data } = await axios.get(url);
-  const children = data.data.children;
+  const children = data.data.children.filter((child: any) => child.data.url.endsWith(".jpg") || child.data.url.endsWith(".png"));
   return children[Math.floor(Math.random() * children.length)].data;
 }
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -445,7 +445,7 @@ export const CONSTANTS = {
   KZILLA_XYZ_SHRINK_URL_ENDPOINT: "https://kzilla.xyz/api/v1/webhook/link",
   JOKES_URL_ENDPOINT:
     "https://official-joke-api.appspot.com/jokes/programming/random",
-  MEMES_API: "https://meme-api.herokuapp.com/gimme/",
+  MEMES_API: "https://www.reddit.com/r/",
   SUB_REDDITS: [
     "ProgrammerHumor/",
     "codinghumor/",
@@ -483,5 +483,5 @@ export const randomMemesEndpoint = () => {
     CONSTANTS.SUB_REDDITS[
       Math.floor(Math.random() * Math.floor(CONSTANTS.SUB_REDDITS.length))
     ]
-  );
+  ).concat(".json");
 };


### PR DESCRIPTION
# Description
`https://meme-api.herokuapp.com/` API which jack used till now died a few months ago, which rendered the `#kzjack meme` command unusable/broken
![image](https://github.com/srm-kzilla/jack/assets/69302420/38dca155-821e-42f9-bb2e-4eb209923c2c)
**Solution**: Directly collect data from the redditAPI, through the link
```js
`https://www.reddit.com/r/${community}.json`
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Tested on Discord

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
